### PR TITLE
Add support for Logstash 2.2.x; break backward compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vagrant
+
+examples/roles/azavea.java

--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@ An Ansible role for installing Logstash.
 ## Role Variables
 
 - `logstash_version` - Logstash version
-- `logstash_disable_logstash_web` - Flag to disable `logstash-web` (default: `True`)
+- `logstash_short_version` - Logstash short version
 
 ## Example Playbook
 
 It is important to note that this role does not include any templates for Logstash configuration. Because Logstash supports `conf.d` style configuration, users of the role are encouraged to write separate Ansible tasks and templates to configure Logstash for their needs.
 
-There is an example template in the [examples](./examples/) directory that reads `/var/log/syslog` and pretty prints a dump of that to `stdout`. Because Logstash is running as a daemon, `stdout` ends up being `/var/log/upstart/logstash.log`.
+There is an example template in the [examples](./examples/) directory that reads `/var/log/syslog` and pretty prints a dump of that to `stdout`. Because Logstash is running as a daemon, `stdout` ends up being captured in `/var/log/logstash/logstash.stdout`.
 
 Running the following command should allow you to confirm that the Logstash `file` input and `stdout` output are working:
 
 ```bash
-$ sudo cat /var/log/upstart/logstash.log
+$ cat /var/log/logstash/logstash.stdout
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
-logstash_version: "1.4.2-1-2c0f5a1"
-logstash_contrib_version: "1.4.2-1-efd53ef"
-logstash_disable_logstash_web: True
+logstash_version: "1:2.2.1-1"
+logstash_short_version: "2.2"

--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -3,6 +3,17 @@
 
 VAGRANTFILE_API_VERSION = "2"
 
+# Ensure role dependencies are in place
+if [ "up", "provision" ].include?(ARGV.first) &&
+  !(File.directory?("roles/azavea.java") || File.symlink?("roles/azavea.java"))
+
+  unless system("ansible-galaxy install --force -r roles.yml -p roles")
+    $stderr.puts "\nERROR: Please install Ansible 1.4.2+ so that the ansible-galaxy binary"
+    $stderr.puts "is available."
+    exit(1)
+  end
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/trusty64"
 

--- a/examples/roles.yml
+++ b/examples/roles.yml
@@ -1,0 +1,2 @@
+- name: azavea.java
+  version: 0.2.1

--- a/examples/templates/logstash.conf.j2
+++ b/examples/templates/logstash.conf.j2
@@ -3,5 +3,5 @@ input {
 }
 
 output {
-  stdout { codec => rubydebug }
+  stdout { }
 }

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,4 +12,5 @@ galaxy_info:
   categories:
   - system
   - monitoring
-dependencies: []
+dependencies:
+  - { role: "azavea.java" }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,20 +1,15 @@
 ---
-- name: Configure Logstash APT key
-  apt_key: url=http://packages.elasticsearch.org/GPG-KEY-elasticsearch state=present
+- name: Configure Elastic APT key
+  apt_key: url=https://packages.elastic.co/GPG-KEY-elasticsearch
+           state=present
 
-- name: Configure the Logstash APT repositories
-  apt_repository: repo="deb http://packages.elasticsearch.org/logstash/1.4/debian stable main" state=present
+- name: Configure the Elastic APT repositories
+  apt_repository: repo="deb http://packages.elastic.co/logstash/{{ logstash_short_version }}/debian stable main"
+                  state=present
 
 - name: Install Logstash
-  apt: pkg={{ item }} state=present update_cache=yes
-  with_items:
-    - logstash={{ logstash_version }}
-    - logstash-contrib={{ logstash_contrib_version }}
+  apt: pkg="logstash={{ logstash_version }}"
+       state=present
 
-- name: Stop Logstash Web service
-  service: name=logstash-web state=stopped
-  when: logstash_disable_logstash_web | bool
-
-- name: Remove Logstash Web service
-  file: path=/etc/init/logstash-web.conf state=absent
-  when: logstash_disable_logstash_web | bool
+- name: Enable the Logstash service
+  service: name=logstash enabled=yes


### PR DESCRIPTION
Install and configure Logstash 2.2.x from the Elastic APT repositories.

---

**Testing**

``` bash
$ cd examples
$ vagrant up
$ vagrant ssh
vagrant@vagrant-ubuntu-trusty-64:~$ tail -f /var/log/logstash/logstash.stdout 
```

Then do something to create `/var/log/syslog` output. An easy way is to do another `vagrant provision`.
